### PR TITLE
forcing page width

### DIFF
--- a/styling.css
+++ b/styling.css
@@ -7,6 +7,7 @@ img {
 #page_container {
     min-height: 100vh;
     position: relative;
+    max-width: 100vw;
 }
 
 a {


### PR DESCRIPTION
- intended to fix bug with iPhone Safari versions of the page stretching out profile picture and placing words outside of view
-bug not detected in Android