### PR TITLE
Fixing face aspect ratio

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 function setLastUpdateText() {
   const days_since_last_edit = Math.floor(
-    (Date.now() - Date.parse("11 Dec 2023")) / (1000 * 60 * 60 * 24)
+    (Date.now() - Date.parse("12 Dec 2023")) / (1000 * 60 * 60 * 24)
   );
   document.getElementById("update_time").innerHTML =
     "Last updated " + days_since_last_edit + " days ago";

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
     </nav>
   </div>
   <div id="transition"></div>
-  <div id="content_container">
     <p id="update_time"></p>
     <div id="about_me">
       <h1>
@@ -37,7 +36,6 @@
       </p>
       <hr>
     </div>
-  </div>
   <div id="footer">
     <p>est. 2023</p>
   </div>

--- a/styling.css
+++ b/styling.css
@@ -1,5 +1,6 @@
-img {
  /* max-width: 100px; */
+ 
+ img {
  height: auto;
  width: auto;
 }
@@ -62,6 +63,7 @@ body {
     padding: 4px;
     background-color: teal;
     margin: 6px;
+    aspect-ratio: 1 / 1;
 }
 
 #about_me {


### PR DESCRIPTION
## Describe issue and/or changes
Solely on iOS (both safari and chrome) the face in the left top corner has the correct height but stretches way past the right edge of the screen.
Forces aspect ratio to be fixed at 1:1.

## link to Trello card
https://trello.com/c/HM0Ltk2W/20-fix-face-stretching-on-ios

## Checklist before requesting a review
- [ ] Local version works on desktop
- [ ] Local version works on mobile
- [ ] Updated "last updated" field
